### PR TITLE
CI: Modify SonarQube settings - exclude coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,9 @@ jobs:
           /o:"aeezin" \
           /d:sonar.host.url="https://sonarcloud.io" \
           /d:sonar.token="${{ secrets.SONAR_TOKEN }}" \
-          /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml" \
           /d:sonar.exclusions="**/bin/**,**/obj/**" \
-          /d:sonar.qualitygate.wait=false 
+          /d:sonar.coverage.exclusions="**/*" \
+          /d:sonar.qualitygate.wait=false
       
     - name: Build
       run: dotnet build HealthCareAB_v1 --no-restore


### PR DESCRIPTION
In an attempt to get rid of the failing Quality Gate SonarCloud from SonarQubeCloud, I Updated the SonarCloud configuration to exclude coverage reports.

