### PR TITLE
Update SonarCloud coverage exclusions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,6 @@ jobs:
                     /d:sonar.host.url="https://sonarcloud.io" \
                     /d:sonar.token="${{ secrets.SONAR_TOKEN }}" \
                     /d:sonar.exclusions="**/bin/**,**/obj/**" \
-                    /d:sonar.coverage.exclusions="**/*" \
                     /d:sonar.qualitygate.wait=false
 
             - name: Build


### PR DESCRIPTION
Removed coverage exclusions from SonarCloud configuration.

This does nothing as we already have coverlet and it may be confusing to the reader that we are also using the SonarCloud exclusion. More about the pipeline being clean than anything else, and showing intent.