### PR TITLE
Allow SonarCloud to read the Coverlet report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
                     /d:sonar.host.url="https://sonarcloud.io" \
                     /d:sonar.token="${{ secrets.SONAR_TOKEN }}" \
                     /d:sonar.exclusions="**/bin/**,**/obj/**" \
+                    /d:sonar.cs.opencover.reportsPaths="**/TestResults/coverage.opencover.xml" \
                     /d:sonar.qualitygate.wait=false
 
             - name: Build


### PR DESCRIPTION
This will hopefully allow SonarCloud analysis to display our test results and not default to 0.00%