### PR TITLE
Fix sonar exclusions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
                     /d:sonar.token="${{ secrets.SONAR_TOKEN }}" \
                     /d:sonar.exclusions="**/bin/**,**/obj/**" \
                     /d:sonar.cs.opencover.reportsPaths="**/TestResults/coverage.opencover.xml" \
-                    /d:sonar.coverage.exclusions="**/medical-app-client/**,**/*.ts,**/*.tsx,**/*.js,**/*.jsx" \
+                    /d:sonar.exclusions="**/medical-app-client/**,**/*.ts,**/*.tsx,**/*.js,**/*.jsx" \
                     /d:sonar.qualitygate.wait=false
 
             - name: Build


### PR DESCRIPTION
Trying to exclude the frontend files