### PR TITLE
Update sonar.coverage.exclusions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,6 @@ jobs:
                     /d:sonar.host.url="https://sonarcloud.io" \
                     /d:sonar.token="${{ secrets.SONAR_TOKEN }}" \
                     /d:sonar.exclusions="**/bin/**,**/obj/**" \
-                    /d:sonar.coverage.exclusions="**/medical-app-client/**,**/*.ts,**/*.tsx,**/*.js,**/*.jsx" \
                     /d:sonar.qualitygate.wait=false
 
             - name: Build


### PR DESCRIPTION
Removed coverage exclusions for specific file types. To see if this is the problem that test coverage fails on new code