### PR TITLE
Fix: Remove exclusion of AppointmentStatus.Cancelled

### DIFF
--- a/HealthCareAB_v1/HealthCareAB_v1/Repositories/Implementations/AppointmentRepository.cs
+++ b/HealthCareAB_v1/HealthCareAB_v1/Repositories/Implementations/AppointmentRepository.cs
@@ -70,8 +70,8 @@ public class AppointmentRepository : IAppointmentRepository
         return await _context.Appointments
             .Where(a => a.CaregiverId == caregiverId &&
                         a.Date >= DateOnly.FromDateTime(startDate) &&
-                        a.Date <= DateOnly.FromDateTime(endDate) &&
-                        a.Status != AppointmentStatus.Cancelled)
+                        a.Date <= DateOnly.FromDateTime(endDate))
+            //          && a.Status != AppointmentStatus.Cancelled
             .ToListAsync();
     }
 


### PR DESCRIPTION
Used in GetByCaregiverAndDateRangeAsync.

Will hopefully now be able to filter out these appointments and view them as unavailable.